### PR TITLE
Add user sign in/up

### DIFF
--- a/awsmobilejs/backend/mobile-hub-project.yml
+++ b/awsmobilejs/backend/mobile-hub-project.yml
@@ -9,6 +9,23 @@ features:
   mobile-analytics: !com.amazonaws.mobilehub.v0.Pinpoint 
     components:
       analytics: !com.amazonaws.mobilehub.v0.PinpointAnalytics {}
-  sign-in: !com.amazonaws.mobilehub.v0.SignIn {}
+  sign-in: !com.amazonaws.mobilehub.v0.SignIn 
+    attributes:
+      enabled: true
+      optional-sign-in: true
+    components:
+      sign-in-user-pools: !com.amazonaws.mobilehub.v0.UserPoolsIdentityProvider 
+        attributes:
+          alias-attributes:
+            - email
+            - phone_number
+          mfa-configuration: ON
+          name: userpool
+          password-policy: !com.amazonaws.mobilehub.ConvertibleMap 
+            min-length: '8'
+            require-lower-case: true
+            require-numbers: true
+            require-symbols: true
+            require-upper-case: true
 name: ServerlessProject-2018-06-08-22-18-21
 region: us-east-1


### PR DESCRIPTION
User Sign Up & Sign In
The first thing we’ll do is look at how we can add user sign up & sign in.
To do so we’ll need to enable it in our Mobile Hub Project.
awsmobile user-signin enable
awsmobile push
Now user signup and signin is enabled through Amazon Cognito and we can immediately start signing users up and in.
If we look at the docs we’ll notice that there are two distinct ways to do this:
We can use the React components & higher order components for preconfigured functionality & UI
We can write this functionality from scratch using the Auth class which contains methods like Auth.signUp() & Auth.signIn()